### PR TITLE
Fix/change message to thread reply

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,13 +100,13 @@ def respondToRequestMsg(body, client:WebClient, ack):
             bot_user_id = os.environ.get('BOT_USER_ID')
             channel = body["event"]["channel"]
             ts = body["event"]["ts"]
-            thread_ts = body["event"].get("thread_ts", None)
+            thread_ts = body["event"].get("thread_ts", ts)
             user = body["event"]["user"]
             attachment_files = body["event"].get("files", None)
 
             # Slackに返答
             # client.chat_postMessage(channel=channel, text=input_text ,thread_ts=ts)
-            client.chat_postEphemeral(user=user, channel=channel, blocks=get_block_message.get_feeling_block(user))
+            client.chat_postMessage(channel=channel, blocks=get_block_message.get_feeling_block(user), thread_ts=thread_ts)
             logger.info(f"respondToRequestMsg - Slackへの投稿完了： {input_text}")
 
             # 投稿内容をDBに保存

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 requests
-Flask==2.2.2
+Flask==2.1.3
 slack_bolt
 slack_sdk
 openai==0.27.4
 python-dotenv==1.0.0
 azure-cosmosdb-table
+werkzeug==2.1.2


### PR DESCRIPTION
Ensure Slack messages are posted as thread replies

Modified the logic in app.py to use `ts` as the fallback for `thread_ts` when it is `None`. This ensures that Slack messages are correctly posted as replies within a thread instead of being treated as new channel posts.